### PR TITLE
Don't allow return statements in statement lists

### DIFF
--- a/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
+++ b/bon-jova-rockstar-implementation/src/main/antlr4/rock/Rockstar.g4
@@ -6,7 +6,7 @@ program: (NL|ws)* (statementList | functionDeclaration)* ws*;
 
 statementList: statement+;
 
-statement: ws* (ifStmt | inputStmt | outputStmt | assignmentStmt | roundingStmt | incrementStmt | decrementStmt | loopStmt | arrayStmt | stringStmt | castStmt | joinStmt | returnStmt | continueStmt | breakStmt) (NL+?|EOF);
+statement: ws* (ifStmt | inputStmt | outputStmt | assignmentStmt | roundingStmt | incrementStmt | decrementStmt | loopStmt | arrayStmt | stringStmt | castStmt | joinStmt | continueStmt | breakStmt) (NL+?|EOF);
 
 
 expression: functionCall
@@ -44,7 +44,7 @@ functionCall: functionName=variable WS KW_TAKING WS argList;
 // the second set of entries here isn't just an expression, to try and force the shortest match, rather than the longest match
 argList: (expression) ((WS KW_AND|COMMA|WS AMPERSAND|WS APOSTROPHED_N) WS (literal|variable|constant|expression))*;
 
-functionDeclaration: functionName=variable WS KW_TAKES WS paramList NL statementList NL;
+functionDeclaration: functionName=variable WS KW_TAKES WS paramList NL statementList? returnStmt (NL+?|EOF);
 
 paramList: variable ((COMMA? WS* KW_AND WS | WS COMMA WS | WS AMPERSAND WS | WS APOSTROPHED_N WS) variable)*;
 

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/BytecodeGeneratorTest.java
@@ -1072,6 +1072,27 @@ names in Rockstar.)
             assertEquals("got this far\n", compileAndLaunch(program));
         }
 
+        @Disabled("This exact code passes when run as an integration test, but fails here - why?!")
+        @Test
+        public void shouldHandleConsecutiveLoops() {
+            String program = """
+                    The walls are high and mighty
+                    While the walls ain't nothing
+                    Knock the walls down
+                                        
+                    Shout the walls
+                                        
+                    Finished are our hopes and dreams
+                    Our city is in need of rebuilding
+                    While our city is not finished
+                    Build our city up
+                                        
+                    Shout our city
+                    """;
+
+            assertEquals("0\n2420\n", compileAndLaunch(program));
+        }
+
         @Test
         public void shouldHandleUntilLoops() {
             String program = """
@@ -2137,6 +2158,25 @@ names in Rockstar.)
                     Say result
                     """;
             assertEquals("A\nA2\nЖ\n", compileAndLaunch(program));
+        }
+
+        @Test
+        public void shouldHandleComplexCasts() {
+            String program = """
+                    The world is only scared
+                    Cast the world into your thoughts
+                    Happiness is a fire
+                    Let your need be the world without happiness
+                    say "your need " + your need
+                    Cast your need into your anger
+                    say "your anger " + your anger
+                    Say "your thoughts" + your thoughts
+                                        """;
+
+            assertEquals("your need 32\n" +
+                    "your anger  \n" +
+                    "your thoughts.\n", compileAndLaunch(program));
+
         }
     }
 

--- a/bon-jova-rockstar-implementation/src/test/java/org/example/integration/IntegrationTests.java
+++ b/bon-jova-rockstar-implementation/src/test/java/org/example/integration/IntegrationTests.java
@@ -74,7 +74,6 @@ public class IntegrationTests {
     }
 
     @Test
-    @Disabled("Not yet working")
     void shouldRunCityWalls() throws IOException, URISyntaxException {
         String output = compileAndLaunch("/concept-demo-4-city-walls.rock");
         String expected = getFileContents("/expected-concept-demo-4-city-walls.output");


### PR DESCRIPTION
They should be counted as part of the function declaration. 

This fixes #104, but I don't entirely understand the mechanism. What's extra confusing is that the same code fails, when run as part of the bytecode generator unit tests - why?!