### PR TITLE
Align Antlr version with one used by Quarkus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,47 +17,15 @@
         <connection>scm:git:https://github.com/quarkiverse/quarkus-bon-jova-rockstar/</connection>
         <url>https://github.com/quarkiverse/quarkus-bon-jova-rockstar/</url>
     </scm>
-    
+
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus.gizmo</groupId>
-                <artifactId>gizmo</artifactId>
-                <version>1.7.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.antlr</groupId>
-                <artifactId>antlr4-runtime</artifactId>
-                <version>4.10.1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.10.0</version>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+   
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.antlr</groupId>
-                <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.10.1</version>
-                <executions>
-                    <execution>
-                        <id>antlr</id>
-                        <goals>
-                            <goal>antlr4</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.0</version>

--- a/quarkus-bon-jova-rockstar/compiler/pom.xml
+++ b/quarkus-bon-jova-rockstar/compiler/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -12,6 +13,14 @@
     <artifactId>bon-jova-rockstar-compiler</artifactId>
     <version>0.4.0-SNAPSHOT</version>
 
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <gizmo.version>1.7.0</gizmo.version>
+        <antlr.version>4.13.0</antlr.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus.gizmo</groupId>
@@ -21,15 +30,17 @@
             <groupId>io.quarkus.gizmo</groupId>
             <artifactId>gizmo</artifactId>
             <type>test-jar</type>
-            <version>1.7.0</version>
+            <version>${gizmo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
+            <version>${antlr.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -39,7 +50,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.10.1</version>
+                <version>${antlr.version}</version>
                 <executions>
                     <execution>
                         <id>antlr</id>


### PR DESCRIPTION
Resolves this output on app start, when running with Quarkus 3.7.1:

```
ANTLR Tool version 4.10.1 used for code generation does not match the current runtime version 4.13.0
ANTLR Runtime version 4.10.1 used for parser compilation does not match the current runtime version 4.13.0
ANTLR Tool version 4.10.1 used for code generation does not match the current runtime version 4.13.0
ANTLR Runtime version 4.10.1 used for parser compilation does not match the current runtime version 4.13.0
```

Quarkus ships with Antlr, and Antlr is annoyingly fussy about cross-version compatibility. We could pull in the Quarkus bom to ensure we were aligned, but that would still ensure alignment for the version of Quarkus the extension was built with.