### PR TITLE
Improved support for nothing and mysterious

### DIFF
--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Constant.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Constant.java
@@ -1,22 +1,41 @@
 package io.quarkiverse.bonjova.compiler;
 
+import io.quarkiverse.bonjova.support.Nothing;
 import io.quarkus.gizmo.AssignableResultHandle;
 import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.BytecodeCreator;
-import io.quarkus.gizmo.CatchBlockCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
-import io.quarkus.gizmo.TryBlock;
 import rock.Rockstar;
 
 import static io.quarkiverse.bonjova.compiler.BytecodeGeneratingListener.isBoolean;
 import static io.quarkiverse.bonjova.compiler.BytecodeGeneratingListener.isNumber;
-import static io.quarkiverse.bonjova.compiler.BytecodeGeneratingListener.isObject;
 import static io.quarkiverse.bonjova.compiler.BytecodeGeneratingListener.isString;
+import static io.quarkiverse.bonjova.compiler.Expression.Operation.ADD;
+import static io.quarkiverse.bonjova.support.Nothing.NOTHING;
+import static io.quarkiverse.bonjova.support.Nothing.NULL;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 
-public class Constant {
+public class Constant implements ValueHolder {
 
-    public static final Object NOTHING = new Nothing(); // TODO this should be the inner class
-
+    public static final String MYSTERIOUS = "mysterious";
+    private static final String EMPTY_STRING = "";
+    public static final MethodDescriptor COERCE_METHOD = MethodDescriptor.ofMethod(Nothing.class, "coerce", Object.class,
+            Object.class);
+    public static final MethodDescriptor COERCE_TO_STRING_METHOD = MethodDescriptor.ofMethod(Nothing.class, "coerceToString",
+            String.class);
+    public static final MethodDescriptor COERCE_TO_NUMBER_METHOD = MethodDescriptor.ofMethod(Nothing.class, "coerceToNumber",
+            Double.class);
+    public static final MethodDescriptor COERCE_TO_BOOLEAN_METHOD = MethodDescriptor.ofMethod(Nothing.class, "coerceToBoolean",
+            Boolean.class);
+    public static final MethodDescriptor COERCE_TO_SOMETHING_METHOD = MethodDescriptor.ofMethod(Nothing.class,
+            "coerceToSomething", Object.class);
+    public static final FieldDescriptor NOTHING_FIELD = FieldDescriptor.of(Nothing.class, "NOTHING", Nothing.class);
+    public static final MethodDescriptor COERCE_METHOD_WITH_VISIBLE_NULLS = MethodDescriptor.ofMethod(Nothing.class,
+            "coerceWithVisibleNulls", Object.class,
+            Object.class);
     private Class<?> valueClass;
     private Object value;
 
@@ -25,15 +44,15 @@ public class Constant {
         if (constant != null) {
             if (constant
                     .CONSTANT_TRUE() != null) {
-                value = true;
+                value = TRUE;
                 valueClass = boolean.class;
             } else if (constant
                     .CONSTANT_FALSE() != null) {
-                value = false;
+                value = FALSE;
                 valueClass = boolean.class;
             } else if (constant
                     .CONSTANT_EMPTY() != null) {
-                value = "";
+                value = EMPTY_STRING;
                 valueClass = String.class;
             } else if (constant
                     .CONSTANT_NULL() != null) {
@@ -48,52 +67,79 @@ public class Constant {
         }
     }
 
-    public static ResultHandle coerceNothingIntoType(BytecodeCreator method, ResultHandle referenceHandle) {
-        if (isNumber(referenceHandle)) {
-            return method.load(0d);
-        } else if (isBoolean(referenceHandle)) {
-            return method.load(false);
-        } else if (isString(referenceHandle)) {
-            return method.load("null");
-        } else if (isObject(referenceHandle)) {
-            // Do a dynamic coercion
-            AssignableResultHandle answer = method.createVariable(Object.class);
+    public static ResultHandle coerceNothingIntoType(BytecodeCreator method, ResultHandle original,
+            ResultHandle referenceHandle, Expression.Operation operation) {
+        AssignableResultHandle answer = method.createVariable(Object.class);
+        // Don't do instanceof checks on a primitive
+        if (isNumber(original) || isBoolean(original)) {
+            // TODO could also bypass stuff for strings? except for mysterious
+            return original;
+        } else {
+            ResultHandle checkResult = method.instanceOf(original, Nothing.class);
+            BranchResult br = method.ifTrue(checkResult);
+            BytecodeCreator isInstance = br.trueBranch();
+            ResultHandle nothingHandle = isInstance.checkCast(original, Nothing.class);
+            if (operation == ADD) {
+                isInstance.assign(answer, isInstance.invokeVirtualMethod(
+                        COERCE_METHOD_WITH_VISIBLE_NULLS, nothingHandle, referenceHandle));
+            } else {
+                isInstance.assign(answer, isInstance.invokeVirtualMethod(
+                        COERCE_METHOD, nothingHandle, referenceHandle));
+            }
 
-            // If the reference is null, casts will all work, but we don't want to coerc, just return null
-            BranchResult br = method.ifNull(referenceHandle);
-            BytecodeCreator trueBranch = br.trueBranch();
-            trueBranch.assign(answer, method.load(0d));
-            // TODO this will be correct for nothing, but incorrect for mysterious
-
-            BytecodeCreator falseBranch = br.falseBranch();
-            TryBlock doubleTryBlock = falseBranch.tryBlock();
-            doubleTryBlock.checkCast(referenceHandle, Double.class);
-            doubleTryBlock.assign(answer, doubleTryBlock.load(0d));
-            CatchBlockCreator doubleCatchBlock = doubleTryBlock.addCatch(ClassCastException.class);
-
-            TryBlock booleanTryBlock = doubleCatchBlock.tryBlock();
-            booleanTryBlock.checkCast(referenceHandle, boolean.class);
-            booleanTryBlock.assign(answer, booleanTryBlock.load(false));
-            CatchBlockCreator booleanCatchBlock = booleanTryBlock.addCatch(ClassCastException.class);
-
-            TryBlock stringTryBlock = booleanCatchBlock.tryBlock();
-            stringTryBlock.checkCast(referenceHandle, boolean.class);
-            stringTryBlock.assign(answer, stringTryBlock.load(""));
-            CatchBlockCreator stringCatchBlock = stringTryBlock.addCatch(ClassCastException.class);
-
-            // We should alsmost never get to this point in the executed code
-            stringCatchBlock.assign(answer, stringTryBlock.loadNull());
-
+            BytecodeCreator isNotInstance = br.falseBranch();
+            // In this case, we can just return the original
+            isNotInstance.assign(answer, original);
             return answer;
+        }
 
+    }
+
+    public static ResultHandle coerceNothingIntoType(BytecodeCreator method, ResultHandle original,
+            Expression.Context context) {
+        AssignableResultHandle answer = method.createVariable(Object.class);
+        // Don't do instanceof checks on a primitive
+        if (isNumber(original) || isBoolean(original)) {
+            // TODO could also bypass stuff for strings? except for mysterious
+            return original;
+        } else {
+            ResultHandle checkResult = method.instanceOf(original, Nothing.class);
+            BranchResult br = method.ifTrue(checkResult);
+            BytecodeCreator isInstance = br.trueBranch();
+            ResultHandle nothingHandle = isInstance.checkCast(original, Nothing.class);
+            if (context == Expression.Context.STRING) {
+                isInstance.assign(answer, isInstance.invokeVirtualMethod(
+                        COERCE_TO_STRING_METHOD, nothingHandle));
+            } else if (context == Expression.Context.SCALAR) {
+                isInstance.assign(answer, isInstance.invokeVirtualMethod(
+                        COERCE_TO_NUMBER_METHOD, nothingHandle));
+            } else if (context == Expression.Context.BOOLEAN) {
+                isInstance.assign(answer, isInstance.invokeVirtualMethod(
+                        COERCE_TO_BOOLEAN_METHOD, nothingHandle));
+            } else {
+                isInstance.assign(answer, isInstance.invokeVirtualMethod(
+                        COERCE_TO_SOMETHING_METHOD, nothingHandle));
+            }
+
+            BytecodeCreator isNotInstance = br.falseBranch();
+            // In this case, we can just return the original
+            isNotInstance.assign(answer, original);
+            return answer;
+        }
+
+    }
+
+    public static ResultHandle coerceMysteriousIntoType(BytecodeCreator method, ResultHandle referenceHandle) {
+        if (isString(referenceHandle)) {
+            return method.load(MYSTERIOUS);
         } else {
             return method.loadNull();
         }
     }
 
-    public static ResultHandle coerceMysteriousIntoType(BytecodeCreator method, ResultHandle referenceHandle) {
-        if (isString(referenceHandle)) {
-            return method.load("mysterious");
+    public static ResultHandle coerceMysteriousIntoType(BytecodeCreator method, Expression.Context context) {
+        if (context == Expression.Context.STRING) {
+            return method.load(MYSTERIOUS);
         } else {
             return method.loadNull();
         }
@@ -105,5 +151,50 @@ public class Constant {
 
     public Class<?> getValueClass() {
         return valueClass;
+    }
+
+    public ResultHandle getResultHandle(BytecodeCreator method) {
+        return getResultHandle(method, Expression.Context.NORMAL);
+    }
+
+    public ResultHandle getResultHandle(BytecodeCreator method, Expression.Context context) {
+        // The only options are true or false, empty string, nothing, or null
+        ResultHandle answer;
+        if (value == TRUE || value == FALSE) {
+            answer = method.load((boolean) value);
+        } else if (value == EMPTY_STRING) {
+            answer = method.load(EMPTY_STRING);
+        } else if (value == NOTHING) { // We can't coerce here, because we have nothing to use as a reference type
+            if (context == Expression.Context.NORMAL) {
+                // TODO at what point should we coerce? is it here, or do we pass nothing around?
+                // TODO combine these - we cannot coerce because we do not have a reference type
+                answer = method.readStaticField(NOTHING_FIELD);
+            } else if (context == Expression.Context.BOOLEAN || context == Expression.Context.SCALAR
+                    || context == Expression.Context.STRING) {
+                // TODO what about the other contexts?
+                answer = coerceNothingIntoType(method, context);
+            } else {
+                answer = method.readStaticField(NOTHING_FIELD);
+            }
+
+        } else if (value == null) {
+            answer = method.loadNull();
+        } else {
+            throw new RuntimeException("Confused constant: Could not interpret type " + valueClass + " with value " + value);
+        }
+        return answer;
+    }
+
+    // TODO change names to make it clear that this is for null, the other is checking
+    private ResultHandle coerceNothingIntoType(BytecodeCreator method, Expression.Context context) {
+        // TODO consolidate this with the other checking logic
+        if (context == Expression.Context.BOOLEAN) {
+            return method.load(false);
+        } else if (context == Expression.Context.SCALAR) {
+            return method.load(0d);
+        } // TODO do we need a context for strings?
+        else {
+            return method.load(NULL);
+        }
     }
 }

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Nothing.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Nothing.java
@@ -1,4 +1,0 @@
-package io.quarkiverse.bonjova.compiler;
-
-public class Nothing {
-}

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/RockFileCompiler.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/RockFileCompiler.java
@@ -2,6 +2,8 @@ package io.quarkiverse.bonjova.compiler;
 
 import io.quarkiverse.bonjova.support.RockstarArray;
 
+import io.quarkiverse.bonjova.support.Nothing;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -34,7 +36,13 @@ public class RockFileCompiler {
     public void compile(InputStream stream, File outFile) throws IOException {
         // Copy across supporting classes
         // TODO check if it exists first rather than always copying
-        Class c = RockstarArray.class;
+        copyClass(outFile, RockstarArray.class);
+        copyClass(outFile, Nothing.class);
+        ClassFileWriter cl = new ClassFileWriter(outFile);
+        new BytecodeGenerator().generateBytecode(stream, getBasename(outFile), cl);
+    }
+
+    private static void copyClass(File outFile, Class c) throws IOException {
         String className = c.getName();
         String classAsPath = className.replace('.', '/') + ".class";
         try (InputStream arrayStream = c.getClassLoader().getResourceAsStream(classAsPath)) {
@@ -46,8 +54,5 @@ public class RockFileCompiler {
                     targetFile.toPath(),
                     StandardCopyOption.REPLACE_EXISTING);
         }
-
-        ClassFileWriter cl = new ClassFileWriter(outFile);
-        new BytecodeGenerator().generateBytecode(stream, getBasename(outFile), cl);
     }
 }

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Rounding.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Rounding.java
@@ -33,7 +33,7 @@ public class Rounding {
     }
 
     public ResultHandle toCode(BytecodeCreator method, ClassCreator creator) {
-        ResultHandle variableContents = variable.read(method);
+        ResultHandle variableContents = variable.getResultHandle(method);
 
         ResultHandle answer = null;
 

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/ValueHolder.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/ValueHolder.java
@@ -1,0 +1,11 @@
+package io.quarkiverse.bonjova.compiler;
+
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ResultHandle;
+
+public interface ValueHolder {
+
+    ResultHandle getResultHandle(BytecodeCreator method);
+
+    ResultHandle getResultHandle(BytecodeCreator method, Expression.Context context);
+}

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Variable.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Variable.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Variable {
+public class Variable implements ValueHolder {
     private static final Map<String, FieldDescriptor> variables = new HashMap<>();
     // Because this is static, we could get cross-talk between programs, but that's a relatively low risk; we manage it by explicitly
     // clearing statics
@@ -90,9 +90,13 @@ public class Variable {
         }
     }
 
-    public ResultHandle read(BytecodeCreator method) {
+    public ResultHandle getResultHandle(BytecodeCreator method) {
         FieldDescriptor field = getField();
         return method.readStaticField(field);
+    }
+
+    public ResultHandle getResultHandle(BytecodeCreator method, Expression.Context context) {
+        return getResultHandle(method);
     }
 
     public void write(BytecodeCreator method, ClassCreator creator, ResultHandle value) {

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/support/Nothing.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/support/Nothing.java
@@ -1,0 +1,59 @@
+package io.quarkiverse.bonjova.support;
+
+import static java.lang.Boolean.FALSE;
+
+public class Nothing {
+    public static final Nothing NOTHING = new Nothing();
+    public static final String NULL = "null";
+    public static final String EMPTY_STRING = "";
+    public static final Double ZERO = Double.valueOf(0d);
+
+    private Nothing() {
+
+    }
+
+    public String toString() {
+        return EMPTY_STRING;
+    }
+
+    public Object coerce(Object reference) {
+        if (reference instanceof Double) {
+            return coerceToNumber();
+        } else if (reference instanceof String) {
+            return toString();
+        } else if (reference instanceof Boolean) {
+            return coerceToBoolean();
+        } else {
+            return coerceToSomething();
+        }
+    }
+
+    public Object coerceWithVisibleNulls(Object reference) {
+        if (reference instanceof Double) {
+            return coerceToNumber();
+        } else if (reference instanceof String) {
+            return coerceToString(); // Note that this is not the same as one gets with toString()!
+        } else if (reference instanceof Boolean) {
+            return coerceToBoolean();
+        } else {
+            return coerceToSomething();
+        }
+    }
+
+    public Boolean coerceToBoolean() {
+        return FALSE;
+    }
+
+    public String coerceToString() {
+        return NULL;
+    }
+
+    public Double coerceToNumber() {
+        return ZERO;
+    }
+
+    public Object coerceToSomething() {
+        return ZERO;
+    }
+
+}

--- a/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/AssignmentTest.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/AssignmentTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import rock.Rockstar;
 
-import static io.quarkiverse.bonjova.compiler.Constant.NOTHING;
+import static io.quarkiverse.bonjova.support.Nothing.NOTHING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -297,7 +297,7 @@ public class AssignmentTest {
         // awfully close to just writing the code down twice, so just be happy if we get here without explosions
     }
 
-    private static void toCode(Assignment a) {
+    private void toCode(Assignment a) {
         ClassCreator creator = ClassCreator.builder()
                 .className("holder")
                 .build();

--- a/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/ConstantTest.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/ConstantTest.java
@@ -1,26 +1,33 @@
 package io.quarkiverse.bonjova.compiler;
 
 import io.quarkiverse.bonjova.compiler.util.ParseHelper;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TestClassLoader;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
 import rock.Rockstar;
 
-import static io.quarkiverse.bonjova.compiler.Constant.NOTHING;
+import java.lang.reflect.InvocationTargetException;
+
+import static io.quarkiverse.bonjova.support.Nothing.NOTHING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConstantTest {
 
     /*
      * empty , silent , and silence are aliases for the empty string ( "" ).
      */
-    @Disabled("type chaos")
     @Test
     public void shouldParseEmptyStringAliases() {
         Rockstar.ConstantContext ctx = new ParseHelper().getConstant("life is silence");
         Constant a = new Constant(ctx);
         assertEquals("", a.getValue());
-        assertEquals(String.class, a.getValueClass());
 
         ctx = new ParseHelper().getConstant("life is silent");
         a = new Constant(ctx);
@@ -101,6 +108,116 @@ public class ConstantTest {
         ctx = new ParseHelper().getConstant("life is gone");
         a = new Constant(ctx);
         assertEquals(NOTHING, a.getValue());
+    }
+
+    @Test
+    public void shouldTreatNothingAsNothingInBytecode() {
+        Rockstar.ConstantContext ctx = new ParseHelper().getConstant("thing is nothing");
+        Constant a = new Constant(ctx);
+        assertEquals(NOTHING, execute(a));
+    }
+
+    @Test
+    public void shouldReturnFalseForNothingInBooleanContexr() {
+        Rockstar.ConstantContext ctx = new ParseHelper().getConstant("say nothing");
+        Constant a = new Constant(ctx);
+
+        assertEquals(false, execute(a, Expression.Context.BOOLEAN));
+    }
+
+    @Test
+    public void shouldReturnZeroForNothingInScalarContext() {
+        Rockstar.ConstantContext ctx = new ParseHelper().getConstant("say nothing");
+        Constant a = new Constant(ctx);
+
+        assertEquals(0d, execute(a, Expression.Context.SCALAR));
+    }
+
+    @Disabled("No string context yet")
+    @Test
+    public void shouldReturnZeroForNothingInStringContext() {
+        Rockstar.ConstantContext ctx = new ParseHelper().getConstant("say nothing");
+        Constant a = new Constant(ctx);
+
+        assertEquals("null", execute(a, Expression.Context.SCALAR));
+    }
+
+    @Test
+    public void shouldTreatMysteriousAsNullInBytecode() {
+        Rockstar.ConstantContext ctx = new ParseHelper().getConstant("thing is mysterious");
+        Constant a = new Constant(ctx);
+        assertNull(execute(a));
+    }
+
+    @Test
+    public void shouldReturnCorrectBytecodeForEmpty() {
+        Rockstar.ConstantContext ctx = new ParseHelper().getConstant("thing is empty");
+        Constant a = new Constant(ctx);
+        assertEquals("", execute(a));
+    }
+
+    @Test
+    public void shouldReturnCorrectBytecodeForFalse() {
+        Rockstar.ConstantContext ctx = new ParseHelper().getConstant("thing is lies");
+        Constant a = new Constant(ctx);
+        assertFalse((Boolean) execute(a));
+    }
+
+    @Test
+    public void shouldReturnCorrectBytecodeForTrue() {
+        Rockstar.ConstantContext ctx = new ParseHelper().getConstant("thing is ok");
+        Constant a = new Constant(ctx);
+        assertTrue((Boolean) execute(a));
+    }
+
+    private Object execute(Constant a) {
+        TestClassLoader cl = new TestClassLoader(this.getClass().getClassLoader());
+
+        // The auto-close on this triggers the write
+        try (ClassCreator creator = ClassCreator.builder()
+                .classOutput(cl)
+                .className("com.MyTest")
+                .build()) {
+
+            MethodCreator method = creator.getMethodCreator("method", Object.class)
+                    .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+            ResultHandle rh = a.getResultHandle(method);
+            method.returnValue(rh);
+        }
+
+        try {
+            Class<?> clazz = cl.loadClass("com.MyTest");
+            return clazz.getMethod("method")
+                    .invoke(null);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Test error: " + e);
+        }
+    }
+
+    private Object execute(Constant a, Expression.Context context) {
+        TestClassLoader cl = new TestClassLoader(this.getClass().getClassLoader());
+
+        // The auto-close on this triggers the write
+        try (ClassCreator creator = ClassCreator.builder()
+                .classOutput(cl)
+                .className("com.MyTest")
+                .build()) {
+
+            MethodCreator method = creator.getMethodCreator("method", Object.class)
+                    .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+            ResultHandle rh = a.getResultHandle(method, context);
+            method.returnValue(rh);
+        }
+
+        try {
+            Class<?> clazz = cl.loadClass("com.MyTest");
+            return clazz.getMethod("method")
+                    .invoke(null);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Test error: " + e);
+        }
     }
 
 }

--- a/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/InputTest.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/InputTest.java
@@ -75,7 +75,7 @@ public class InputTest {
                     .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
 
             Variable v = a.toCode(creator, method, method);
-            ResultHandle rh = v.read(method);
+            ResultHandle rh = v.getResultHandle(method);
             method.returnValue(rh);
         }
 

--- a/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/VariableTest.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/VariableTest.java
@@ -240,7 +240,7 @@ public class VariableTest {
         String className = "soundcheck";
         ResultHandle writtenValue = method.load(className);
         variable.write(method, creator, writtenValue);
-        ResultHandle readValue = variable.read(method);
+        ResultHandle readValue = variable.getResultHandle(method);
 
         // Ignore the number in our comparison
         readValue.setNo(0);
@@ -264,7 +264,7 @@ public class VariableTest {
         String className = "soundcheck";
         ResultHandle writtenValue = method.load(className);
         variable.write(method, creator, writtenValue);
-        ResultHandle readValue = variable.read(method);
+        ResultHandle readValue = variable.getResultHandle(method);
         assertTrue(readValue.toString().contains("type='Ljava/lang/String;'"), readValue.toString());
 
         Rockstar.VariableContext ctx2 = new ParseHelper().getVariable("johnny is 4");
@@ -273,7 +273,7 @@ public class VariableTest {
         assertEquals(double.class, variable2.getVariableClass());
         ResultHandle writtenValue2 = method.load(2d);
         variable2.write(method, creator, writtenValue2);
-        ResultHandle readValue2 = variable2.read(method);
+        ResultHandle readValue2 = variable2.getResultHandle(method);
 
         assertTrue(readValue2.toString().contains("type='D'"), readValue2.toString());
     }

--- a/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/support/NothingTest.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/support/NothingTest.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.bonjova.support;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NothingTest {
+
+    Nothing nothing = Nothing.NOTHING;
+
+    @Test
+    public void shouldImplementToString() {
+        assertEquals("", nothing.toString());
+    }
+
+    @Test
+    public void shouldCoerceToFalseInBooleanContext() {
+        assertEquals(false, nothing.coerce(true));
+    }
+
+    @Test
+    public void shouldCoerceToEmptyTextInStringContext() {
+        assertEquals("", nothing.coerce("whatever"));
+    }
+
+    @Test
+    public void shouldCoerceToEmptyStringInNumberContext() {
+        assertEquals(0d, nothing.coerce(42d));
+    }
+
+    // Spec is ambiguous, but Satriani coerces to zero
+    @Test
+    public void shouldCoerceToZeroInAmbiguousContext() {
+        assertEquals(0d, nothing.coerce(null));
+    }
+
+}

--- a/quarkus-bon-jova-rockstar/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/quarkus-bon-jova-rockstar/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:project-version: 0.3.0
+:project-version: 0.6.0
 :pact-version: ${pact.version}
 
 :examples-dir: ./../examples/

--- a/quarkus-bon-jova-rockstar/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/quarkus-bon-jova-rockstar/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,3 @@
 :project-version: 0.6.0
-:pact-version: ${pact.version}
 
 :examples-dir: ./../examples/

--- a/quarkus-bon-jova-rockstar/docs/templates/includes/attributes.adoc
+++ b/quarkus-bon-jova-rockstar/docs/templates/includes/attributes.adoc
@@ -1,4 +1,3 @@
 :project-version: ${release.current-version}
-:pact-version: ${pact.version}
 
 :examples-dir: ./../examples/


### PR DESCRIPTION
To distinguish between nothing and mysterious, we need a type. I've added a Nothing type, with behaviours. This allows us to enable several of the mysterious-related tests. 

There's still lots of todos in the code about coercion, and lots of messiness that could be tidied up, but I think this is a step in the right direction. 

Resolves #98.