### PR TITLE
Scope variables with access to parent scope, and introduce parameter behaviour for function calls

### DIFF
--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Assignment.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Assignment.java
@@ -3,7 +3,6 @@ package io.quarkiverse.bonjova.compiler;
 import io.quarkiverse.bonjova.compiler.grammar.PoeticNumberLiteral;
 import io.quarkiverse.bonjova.support.Nothing;
 import io.quarkus.gizmo.BytecodeCreator;
-import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import rock.Rockstar;
@@ -87,17 +86,19 @@ public class Assignment {
     }
 
     // TODO make argument order consistent across related classes
-    public void toCode(ClassCreator creator, BytecodeCreator method) {
+    public void toCode(Block block) {
 
         ResultHandle rh;
 
         if (expression != null) {
-            rh = expression.getResultHandle(method, creator);
+            rh = expression.getResultHandle(block);
         } else if (arrayAccess != null) {
-            rh = arrayAccess.pop(method, creator);
+            rh = arrayAccess.pop(block);
         } else {
             // TODO it's now really big This code is duplicated in Expression, but it's probably a bit too small to be worth extracting
             Object value = getValue();
+
+            BytecodeCreator method = block.method();
 
             if (String.class.equals(variableClass)) {
                 rh = method.load((String) value);
@@ -122,7 +123,7 @@ public class Assignment {
             }
         }
 
-        variable.write(method, creator, rh);
+        variable.write(block, rh);
 
     }
 }

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Block.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Block.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.bonjova.compiler;
+
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ClassCreator;
+import org.antlr.v4.runtime.ParserRuleContext;
+
+public record Block(ParserRuleContext ctx, BytecodeCreator method, ClassCreator creator, VariableScope variables,
+        Block parent) {
+
+    // The ctx is not strictly necessary, but very useful for debugging
+
+}

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Cast.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Cast.java
@@ -3,7 +3,6 @@ package io.quarkiverse.bonjova.compiler;
 import io.quarkus.gizmo.AssignableResultHandle;
 import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.BytecodeCreator;
-import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import rock.Rockstar;
@@ -27,10 +26,12 @@ public class Cast {
         this.ctx = ctx;
     }
 
-    public ResultHandle toCode(BytecodeCreator method, ClassCreator creator) {
+    public ResultHandle toCode(Block block) {
 
         Rockstar.ExpressionContext sourceExpression = ctx.expression().get(0);
-        ResultHandle oldVal = new Expression(sourceExpression).getResultHandle(method, creator);
+        ResultHandle oldVal = new Expression(sourceExpression).getResultHandle(block);
+
+        BytecodeCreator method = block.method();
 
         // Handle casting things that aren't strings
         ResultHandle isString = method.instanceOf(oldVal, String.class);
@@ -41,7 +42,7 @@ public class Cast {
         if (ctx.KW_WITH() != null) {
             //Satriani gives a NaN if the 'with' isn't 16, so this is doing better than it (although we ignore floating points because priorities)
             ResultHandle intRadix = isStringBranch.invokeVirtualMethod(INTVALUE_METHOD,
-                    new Expression(ctx.expression(1)).getResultHandle(method, creator));
+                    new Expression(ctx.expression(1)).getResultHandle(block));
             ResultHandle parsedInteger = isStringBranch.invokeStaticMethod(RADIX_VALUE_OF_METHOD, oldVal, intRadix);
             ResultHandle resultHandle = isStringBranch.invokeVirtualMethod(DOUBLE_FROM_INTEGER_METHOD, parsedInteger);
             isStringBranch.assign(newVal, resultHandle);
@@ -71,7 +72,7 @@ public class Cast {
                 newVar = oldVar;
             }
         }
-        newVar.write(method, creator, newVal);
+        newVar.write(block, newVal);
 
         return newVal;
     }

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Condition.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Condition.java
@@ -1,8 +1,6 @@
 package io.quarkiverse.bonjova.compiler;
 
 import io.quarkus.gizmo.BranchResult;
-import io.quarkus.gizmo.BytecodeCreator;
-import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ResultHandle;
 import rock.Rockstar;
 
@@ -15,9 +13,9 @@ public class Condition {
         hasElse = ctx.KW_ELSE() != null;
     }
 
-    public BranchResult toCode(BytecodeCreator main, ClassCreator classCreator) {
-        ResultHandle evaluated = expression.getResultHandle(main, classCreator, Expression.Context.BOOLEAN);
-        BranchResult conditional = main.ifTrue(evaluated);
+    public BranchResult toCode(Block block) {
+        ResultHandle evaluated = expression.getResultHandle(block, Expression.Context.BOOLEAN);
+        BranchResult conditional = block.method().ifTrue(evaluated);
         return conditional;
     }
 

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Constant.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Constant.java
@@ -95,8 +95,9 @@ public class Constant implements ValueHolder {
 
     }
 
-    public static ResultHandle coerceNothingIntoType(BytecodeCreator method, ResultHandle original,
+    public static ResultHandle coerceNothingIntoType(Block block, ResultHandle original,
             Expression.Context context) {
+        BytecodeCreator method = block.method();
         AssignableResultHandle answer = method.createVariable(Object.class);
         // Don't do instanceof checks on a primitive
         if (isNumber(original) || isBoolean(original)) {
@@ -153,11 +154,12 @@ public class Constant implements ValueHolder {
         return valueClass;
     }
 
-    public ResultHandle getResultHandle(BytecodeCreator method) {
-        return getResultHandle(method, Expression.Context.NORMAL);
+    public ResultHandle getResultHandle(Block block) {
+        return getResultHandle(block, Expression.Context.NORMAL);
     }
 
-    public ResultHandle getResultHandle(BytecodeCreator method, Expression.Context context) {
+    public ResultHandle getResultHandle(Block block, Expression.Context context) {
+        BytecodeCreator method = block.method();
         // The only options are true or false, empty string, nothing, or null
         ResultHandle answer;
         if (value == TRUE || value == FALSE) {

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Input.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Input.java
@@ -41,7 +41,10 @@ public class Input {
         return variableClass;
     }
 
-    public Variable toCode(ClassCreator creator, BytecodeCreator method, MethodCreator main) {
+    public Variable toCode(Block block, MethodCreator main) {
+
+        BytecodeCreator method = block.method();
+        ClassCreator creator = block.creator();
 
         if (indexField == null) {
             indexField = creator.getFieldCreator("inputIndex", int.class)
@@ -58,7 +61,7 @@ public class Input {
         CatchBlockCreator catchBlock = tryBlock.addCatch(Throwable.class);
         catchBlock.assign(answer, catchBlock.loadNull());
 
-        variable.write(method, creator, answer);
+        variable.write(block, answer);
         method.writeStaticField(indexField, method.add(index, method.load(1)));
 
         return variable;

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Literal.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Literal.java
@@ -43,16 +43,17 @@ public class Literal implements ValueHolder {
         return valueClass;
     }
 
-    public ResultHandle getResultHandle(BytecodeCreator method) {
-        return getResultHandle(method, value, valueClass);
+    public ResultHandle getResultHandle(Block block) {
+        return getResultHandle(block, value, valueClass);
     }
 
-    public ResultHandle getResultHandle(BytecodeCreator method, Expression.Context content) {
+    public ResultHandle getResultHandle(Block block, Expression.Context content) {
         // No context makes a difference to things we can define as literals
-        return getResultHandle(method);
+        return getResultHandle(block);
     }
 
-    static ResultHandle getResultHandle(BytecodeCreator method, Object value, Class<?> valueClass) {
+    static ResultHandle getResultHandle(Block block, Object value, Class<?> valueClass) {
+        BytecodeCreator method = block.method();
         ResultHandle answer;
         // We do not need to handle nothing
         // TODO do we need to handle mysterious? I don't think so?

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Parameter.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Parameter.java
@@ -1,0 +1,105 @@
+package io.quarkiverse.bonjova.compiler;
+
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.objectweb.asm.Opcodes;
+import rock.Rockstar;
+
+public class Parameter extends Variable {
+
+    public Parameter(Rockstar.VariableContext variable, Class<?> variableClass) {
+        this(variable.getText(), variable.PRONOUNS(), variableClass);
+    }
+
+    private Parameter(String text, TerminalNode pronouns, Class<?> variableClass) {
+        this(text, pronouns, false);
+
+        this.variableClass = variableClass;
+        // TODO type chaos
+        this.variableClass = Object.class;
+    }
+
+    public Parameter(Rockstar.VariableContext variable) {
+        this(variable, true);
+    }
+
+    private Parameter(Rockstar.VariableContext variable, boolean enforceType) {
+        this(variable.getText(), variable.PRONOUNS(), enforceType);
+    }
+
+    private Parameter(String text, TerminalNode pronouns, boolean enforceType) {
+        super(text, pronouns, enforceType);
+        // Work out the variable name
+        // In principle trivial, in practice made a bit complicated by normalisation and more complicated by pronouns
+        // TODO type chaos
+        this.variableClass = Object.class;
+
+        if (pronouns != null) {
+            // This could be an internal error or a program one
+            throw new RuntimeException("Cannot use pronouns in function declarations");
+        }
+    }
+
+    /*
+     * Pronouns refer to the last named variable determined by parsing order.
+     * In practice, this is only on assignment, not on any reference, so this needs to be triggered externally.
+     */
+    @Override
+    public void track() {
+        // Pronouns don't apply to parameters; do nothing
+    }
+
+    @Override
+    public ResultHandle getResultHandle(Block block) {
+        FieldDescriptor field = getField(block);
+        // TODO not a static field
+        return block.method().readStaticField(field);
+    }
+
+    @Override
+    public void write(Block block, ResultHandle value) {
+        FieldDescriptor field = getOrCreateField(block);
+
+        // TODO a parameter is not a static field, but it might be modifiable, so we can't just always reference the function param by index
+        block.method().writeStaticField(field, value);
+    }
+
+    @Override
+    protected FieldDescriptor getField(Block block) {
+        FieldDescriptor field;
+        if (isAlreadyWritten(block)) {
+            field = block.variables().get(variableName);
+
+        } else {
+            // This is an internal error, not a program one
+
+            throw new RuntimeException("Moral panic: Could not find variable called " + variableName
+                    + ". \nKnown variables are " + block.variables().getAllKnownVariables());
+        }
+
+        return field;
+    }
+
+    @Override
+    protected FieldDescriptor getOrCreateField(Block block) {
+        FieldDescriptor field;
+        ClassCreator creator = block.creator();
+        if (!isAlreadyWritten(block)) {
+            // Variables are global in method, so need to be stored at the class level (either as static or instance variables)
+            field = creator.getFieldCreator(variableName, variableClass)
+                    .setModifiers(Opcodes.ACC_STATIC + Opcodes.ACC_PRIVATE)
+                    .getFieldDescriptor();
+
+            block.variables().put(variableName, field);
+        } else {
+            field = getField(block);
+            if (!creator.getClassName().equals(field.getDeclaringClass())) {
+                throw new RuntimeException("Internal error: Attempting to use a field on class " + field.getDeclaringClass()
+                        + " from " + creator.getClassName());
+            }
+        }
+        return field;
+    }
+}

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Rounding.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/Rounding.java
@@ -1,7 +1,6 @@
 package io.quarkiverse.bonjova.compiler;
 
 import io.quarkus.gizmo.BytecodeCreator;
-import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import rock.Rockstar;
@@ -32,8 +31,9 @@ public class Rounding {
         }
     }
 
-    public ResultHandle toCode(BytecodeCreator method, ClassCreator creator) {
-        ResultHandle variableContents = variable.getResultHandle(method);
+    public ResultHandle toCode(Block block) {
+        BytecodeCreator method = block.method();
+        ResultHandle variableContents = variable.getResultHandle(block);
 
         ResultHandle answer = null;
 
@@ -52,7 +52,7 @@ public class Rounding {
 
         // Write the update back to the variable
         if (variable != null) {
-            variable.write(method, creator, answer);
+            variable.write(block, answer);
         }
 
         // Also return the result handle, for ease of testing

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/StringSplit.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/StringSplit.java
@@ -2,7 +2,6 @@ package io.quarkiverse.bonjova.compiler;
 
 import io.quarkus.gizmo.AssignableResultHandle;
 import io.quarkus.gizmo.BytecodeCreator;
-import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.gizmo.WhileLoop;
@@ -57,13 +56,14 @@ public class StringSplit {
         return variable.getVariableName();
     }
 
-    public ResultHandle toCode(BytecodeCreator method, ClassCreator creator) {
+    public ResultHandle toCode(Block inBlock) {
 
-        ResultHandle toSplit = source.getResultHandle(method, creator);
+        BytecodeCreator method = inBlock.method();
+        ResultHandle toSplit = source.getResultHandle(inBlock);
         ResultHandle answer = method.newInstance(Array.CONSTRUCTOR);
 
         if (delimiter != null) {
-            ResultHandle delimiterHandle = delimiter.getResultHandle(method, creator);
+            ResultHandle delimiterHandle = delimiter.getResultHandle(inBlock);
             ResultHandle splitArray = method.invokeVirtualMethod(SPLIT_METHOD, toSplit, delimiterHandle);
             ResultHandle splitList = method.invokeStaticMethod(ASLIST_METHOD, splitArray);
             method.invokeVirtualMethod(ADD_ALL_METHOD, answer, splitList);
@@ -83,7 +83,7 @@ public class StringSplit {
             block.assign(index, block.increment(index));
         }
 
-        variable.write(method, creator, answer);
+        variable.write(inBlock, answer);
 
         // Return the result handle for ease of testing
         return answer;

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/ValueHolder.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/ValueHolder.java
@@ -1,11 +1,10 @@
 package io.quarkiverse.bonjova.compiler;
 
-import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ResultHandle;
 
 public interface ValueHolder {
 
-    ResultHandle getResultHandle(BytecodeCreator method);
+    ResultHandle getResultHandle(Block block);
 
-    ResultHandle getResultHandle(BytecodeCreator method, Expression.Context context);
+    ResultHandle getResultHandle(Block block, Expression.Context context);
 }

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/VariableScope.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/VariableScope.java
@@ -1,0 +1,23 @@
+package io.quarkiverse.bonjova.compiler;
+
+import io.quarkus.gizmo.FieldDescriptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class VariableScope {
+
+    private final Map<String, FieldDescriptor> variables = new HashMap<>();
+
+    public FieldDescriptor get(String variableName) {
+        return variables.get(variableName);
+    }
+
+    public Object[] getAllKnownVariables() {
+        return variables.keySet().toArray();
+    }
+
+    public void put(String variableName, FieldDescriptor field) {
+        variables.put(variableName, field);
+    }
+}

--- a/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/ArrayTest.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/ArrayTest.java
@@ -6,6 +6,7 @@ import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.gizmo.TestClassLoader;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
@@ -53,13 +54,13 @@ public class ArrayTest {
     @Test
     public void shouldCreateAnArrayOnInitialisationWithRock() {
         Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray("Rock the thing");
-        assertEquals(new ArrayList<Object>(), execute(new Array(ctx)).list);
+        assertEquals(new ArrayList<Object>(), execute(ctx, new Array(ctx)).list);
     }
 
     @Test
     public void shouldCreateAnArrayOnInitialisationWithPush() {
         Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray("Push the thing");
-        assertEquals(new ArrayList<Object>(), execute(new Array(ctx)).list);
+        assertEquals(new ArrayList<Object>(), execute(ctx, new Array(ctx)).list);
     }
 
     @Test
@@ -69,7 +70,7 @@ public class ArrayTest {
                 """;
         Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray(program);
         Object[] contents = { 4d };
-        assertEquals(Arrays.asList(contents), execute(new Array(ctx)).list);
+        assertEquals(Arrays.asList(contents), execute(ctx, new Array(ctx)).list);
 
     }
 
@@ -80,7 +81,7 @@ public class ArrayTest {
                 """;
         Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray(program);
         Object[] contents = { 1d, 2d, 3d, 4d, 8d };
-        assertEquals(Arrays.asList(contents), execute(new Array(ctx)).list);
+        assertEquals(Arrays.asList(contents), execute(ctx, new Array(ctx)).list);
     }
 
     @Test
@@ -90,7 +91,7 @@ public class ArrayTest {
                 """;
         Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray(program);
         Object[] contents = { 5d };
-        assertEquals(Arrays.asList(contents), execute(new Array(ctx)).list);
+        assertEquals(Arrays.asList(contents), execute(ctx, new Array(ctx)).list);
     }
 
     @Test
@@ -100,7 +101,7 @@ public class ArrayTest {
                 """;
         Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray(program);
         Object[] contents = { 1d, 2d, 3d, 4d, 8d };
-        assertEquals(Arrays.asList(contents), execute(new Array(ctx)).list);
+        assertEquals(Arrays.asList(contents), execute(ctx, new Array(ctx)).list);
     }
 
     @Test
@@ -110,7 +111,7 @@ public class ArrayTest {
                 """;
         Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray(program);
         Object[] contents = { 9d };
-        assertEquals(Arrays.asList(contents), execute(new Array(ctx)).list);
+        assertEquals(Arrays.asList(contents), execute(ctx, new Array(ctx)).list);
     }
 
     @Test
@@ -120,7 +121,7 @@ public class ArrayTest {
                 """;
         Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray(program);
         Object[] contents = { 2d };
-        assertEquals(Arrays.asList(contents), execute(new Array(ctx)).list);
+        assertEquals(Arrays.asList(contents), execute(ctx, new Array(ctx)).list);
     }
 
     @Test
@@ -130,7 +131,7 @@ public class ArrayTest {
                 """;
         Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray(program);
         Object[] contents = { null, null, null, null, null, 2d };
-        assertEquals(Arrays.asList(contents), execute(new Array(ctx)).list);
+        assertEquals(Arrays.asList(contents), execute(ctx, new Array(ctx)).list);
     }
 
     @Test
@@ -139,7 +140,7 @@ public class ArrayTest {
                 Let arr at "hello" be 2
                 """;
         Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray(program);
-        RockstarArray execute = execute(new Array(ctx));
+        RockstarArray execute = execute(ctx, new Array(ctx));
         assertEquals(2d, execute.get("hello"));
     }
 
@@ -149,13 +150,13 @@ public class ArrayTest {
                 Rock 1, 2 into arr
                 """;
         Rockstar.ArrayStmtContext ctx = new ParseHelper().getArray(program);
-        RockstarArray execute = execute(new Array(ctx));
+        RockstarArray execute = execute(ctx, new Array(ctx));
         assertEquals(null, execute.get(5));
     }
 
     // We can't test reading arrays because they're multi-line executions
 
-    private RockstarArray execute(Array a) {
+    private RockstarArray execute(ParserRuleContext ctx, Array a) {
         TestClassLoader cl = new TestClassLoader(this.getClass().getClassLoader());
 
         // The auto-close on this triggers the write
@@ -168,7 +169,8 @@ public class ArrayTest {
 
             MethodCreator method = creator.getMethodCreator(methodName, Object.class)
                     .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
-            ResultHandle rh = a.toCode(method, creator);
+            Block block = new Block(ctx, method, creator, new VariableScope(), null);
+            ResultHandle rh = a.toCode(block);
             method.returnValue(rh);
         }
 

--- a/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/AssignmentTest.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/AssignmentTest.java
@@ -3,6 +3,7 @@ package io.quarkiverse.bonjova.compiler;
 import io.quarkiverse.bonjova.compiler.util.ParseHelper;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.MethodCreator;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import rock.Rockstar;
@@ -263,7 +264,7 @@ public class AssignmentTest {
         Rockstar.AssignmentStmtContext ctx = new ParseHelper().getAssignment("My thing is nothing");
         Assignment a = new Assignment(ctx);
 
-        toCode(a);
+        toCode(ctx, a);
         // It's hard to make many sensible assertions without making a mock and asserting about to the calls, and that's
         // awfully close to just writing the code down twice, so just be happy if we get here without explosions
     }
@@ -292,18 +293,20 @@ public class AssignmentTest {
     public void shouldWriteToClass() {
         Rockstar.AssignmentStmtContext ctx = new ParseHelper().getAssignment("My thing is \"hello\"\nEverything is my thing");
         Assignment a = new Assignment(ctx);
-        toCode(a);
+        toCode(ctx, a);
         // It's hard to make many sensible assertions without making a mock and asserting about to the calls, and that's
         // awfully close to just writing the code down twice, so just be happy if we get here without explosions
     }
 
-    private void toCode(Assignment a) {
+    private void toCode(ParserRuleContext ctx, Assignment a) {
         ClassCreator creator = ClassCreator.builder()
                 .className("holder")
                 .build();
         MethodCreator method = creator.getMethodCreator("main", void.class, String[].class);
 
-        a.toCode(creator, method);
+        Block block = new Block(ctx, method, creator, new VariableScope(), null);
+
+        a.toCode(block);
     }
 
 }

--- a/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/CastTest.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/CastTest.java
@@ -6,9 +6,11 @@ import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.gizmo.TestClassLoader;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
+import rock.Rockstar;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -19,33 +21,36 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class CastTest {
     @Test
     public void shouldCastDoubleToString() {
-        Cast cast = new Cast(new ParseHelper().getCast("Cast \"124.45\" into X"));
-        assertEquals(124.45d, execute(cast));
+        Rockstar.CastStmtContext ctx = new ParseHelper().getCast("Cast \"124.45\" into X");
+        Cast cast = new Cast(ctx);
+        assertEquals(124.45d, execute(ctx, cast));
     }
 
     @Test
     public void shouldCastStringToDoubleWithConversionBases() {
-        Cast cast = new Cast(new ParseHelper().getCast("Cast \"ff\" into X with 16"));
+        Rockstar.CastStmtContext ctx = new ParseHelper().getCast("Cast \"ff\" into X with 16");
+        Cast cast = new Cast(ctx);
         // X now contains the numeric value 255 - OxFF
-        assertEquals(255d, execute(cast));
+        assertEquals(255d, execute(ctx, cast));
 
         cast = new Cast(new ParseHelper().getCast("Cast \"aa\" into result with 16"));
         // result now contains the number 170 - 0xAA
-        assertEquals(170, execute(cast));
+        assertEquals(170, execute(ctx, cast));
     }
 
     @Test
     public void shouldCastDoubleToStringAsUnicode() {
-        Cast cast = new Cast(new ParseHelper().getCast("Cast 65 into X"));
+        Rockstar.CastStmtContext ctx = new ParseHelper().getCast("Cast 65 into X");
+        Cast cast = new Cast(ctx);
         // X now contains the numeric value 255 - OxFF
-        assertEquals("A", execute(cast));
+        assertEquals("A", execute(ctx, cast));
 
         cast = new Cast(new ParseHelper().getCast("Cast 1046 into result"));
         // result now contains the Cyrillic letter "Ж" - Unicode code point 1046
-        assertEquals("Ж", execute(cast));
+        assertEquals("Ж", execute(ctx, cast));
     }
 
-    private RockstarArray execute(Cast a) {
+    private RockstarArray execute(ParserRuleContext ctx, Cast a) {
         TestClassLoader cl = new TestClassLoader(this.getClass().getClassLoader());
 
         // The auto-close on this triggers the write
@@ -58,7 +63,9 @@ public class CastTest {
 
             MethodCreator method = creator.getMethodCreator(methodName, Object.class)
                     .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
-            ResultHandle rh = a.toCode(method, creator);
+            Block block = new Block(ctx, method, creator, new VariableScope(), null);
+
+            ResultHandle rh = a.toCode(block);
             method.returnValue(rh);
         }
 

--- a/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/ExpressionTest.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/ExpressionTest.java
@@ -5,6 +5,7 @@ import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.gizmo.TestClassLoader;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -139,7 +140,7 @@ public class ExpressionTest {
 
         // The value of nothing is context-dependent, but on its own it should stay as the nothing object, so that other higher-level expressions and
         // output statements can do the right thing
-        assertEquals(NOTHING, execute(a));
+        assertEquals(NOTHING, execute(ctx, a));
 
     }
 
@@ -150,7 +151,7 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say lies");
             Expression a = new Expression(ctx);
 
-            assertEquals(false, execute(a, Expression.Context.BOOLEAN));
+            assertEquals(false, execute(ctx, a, Expression.Context.BOOLEAN));
         }
 
         @Test
@@ -158,7 +159,7 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say nothing");
             Expression a = new Expression(ctx);
 
-            assertEquals(false, execute(a, Expression.Context.BOOLEAN));
+            assertEquals(false, execute(ctx, a, Expression.Context.BOOLEAN));
         }
 
         @Test
@@ -166,7 +167,7 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say nothing");
             Expression a = new Expression(ctx);
 
-            assertEquals(0d, execute(a, Expression.Context.SCALAR));
+            assertEquals(0d, execute(ctx, a, Expression.Context.SCALAR));
         }
 
         @Test
@@ -174,7 +175,7 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say mysterious");
             Expression a = new Expression(ctx);
 
-            assertEquals(false, execute(a, Expression.Context.BOOLEAN));
+            assertEquals(false, execute(ctx, a, Expression.Context.BOOLEAN));
         }
 
         @Test
@@ -182,7 +183,7 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say 0");
             Expression a = new Expression(ctx);
 
-            assertEquals(false, execute(a, Expression.Context.BOOLEAN));
+            assertEquals(false, execute(ctx, a, Expression.Context.BOOLEAN));
         }
 
         @Test
@@ -190,7 +191,7 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say ok");
             Expression a = new Expression(ctx);
 
-            assertEquals(true, execute(a, Expression.Context.BOOLEAN));
+            assertEquals(true, execute(ctx, a, Expression.Context.BOOLEAN));
         }
 
         @Test
@@ -198,7 +199,7 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say \"hello\"");
             Expression a = new Expression(ctx);
 
-            assertEquals(true, execute(a, Expression.Context.BOOLEAN));
+            assertEquals(true, execute(ctx, a, Expression.Context.BOOLEAN));
         }
 
         @Test
@@ -206,7 +207,7 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say 42");
             Expression a = new Expression(ctx);
 
-            assertEquals(true, execute(a, Expression.Context.BOOLEAN));
+            assertEquals(true, execute(ctx, a, Expression.Context.BOOLEAN));
         }
     }
 
@@ -219,7 +220,7 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout 3 + 6", 0);
             Expression a = new Expression(ctx);
             assertNull(a.getValue());
-            double answer = (double) execute(a);
+            double answer = (double) execute(ctx, a);
             assertEquals(9d, answer);
         }
 
@@ -228,12 +229,12 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout 3 plus 6", 0);
             Expression a = new Expression(ctx);
             assertNull(a.getValue());
-            double answer = (double) execute(a);
+            double answer = (double) execute(ctx, a);
             assertEquals(9d, answer);
 
             ctx = new ParseHelper().getExpression("shout 8 with 5", 0);
             a = new Expression(ctx);
-            answer = (double) execute(a);
+            answer = (double) execute(ctx, a);
             assertEquals(13d, answer);
         }
 
@@ -241,7 +242,7 @@ public class ExpressionTest {
         public void shouldHandleStringAddition() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say \"rock\" plus \"roll\"", 0);
             Expression e = new Expression(ctx);
-            String answer = (String) execute(e);
+            String answer = (String) execute(ctx, e);
             assertEquals("rockroll", answer);
         }
 
@@ -249,12 +250,12 @@ public class ExpressionTest {
         public void shouldFormatNumbersCorrectlyOnStringAddition() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say 99 plus \" red balloons\"", 0);
             Expression e = new Expression(ctx);
-            String answer = (String) execute(e);
+            String answer = (String) execute(ctx, e);
             assertEquals("99 red balloons", answer);
 
             ctx = new ParseHelper().getExpression("say \"blink\" plus 42", 0);
             e = new Expression(ctx);
-            answer = (String) execute(e);
+            answer = (String) execute(ctx, e);
             assertEquals("blink42", answer);
         }
 
@@ -266,13 +267,13 @@ public class ExpressionTest {
             // Make sure we have the right expression
             assertEquals("nothing plus \" points\"", ctx.getText());
             Expression a = new Expression(ctx);
-            assertEquals("null points", execute(a));
+            assertEquals("null points", execute(ctx, a));
 
             // Now swap the order
             ctx = new ParseHelper().getExpression("shout  \"points \" plus nothing", 0);
             assertEquals("\"points \" plus nothing", ctx.getText());
             a = new Expression(ctx);
-            assertEquals("points null", execute(a));
+            assertEquals("points null", execute(ctx, a));
         }
 
         @Test
@@ -282,13 +283,13 @@ public class ExpressionTest {
             Expression a = new Expression(ctx);
             // Make sure we have the right expression
             assertEquals("nothing plus 42", ctx.getText());
-            assertEquals(42d, execute(a));
+            assertEquals(42d, execute(ctx, a));
 
             // Now swap the order
             ctx = new ParseHelper().getExpression("shout 42 plus nothing", 0);
             assertEquals("42 plus nothing", ctx.getText());
             a = new Expression(ctx);
-            assertEquals(42d, execute(a));
+            assertEquals(42d, execute(ctx, a));
         }
 
         @Test
@@ -298,7 +299,7 @@ public class ExpressionTest {
             // Make sure we have the right expression
             assertEquals("mysterious plus \" ways\"", ctx.getText());
             Expression a = new Expression(ctx);
-            assertEquals("mysterious ways", execute(a));
+            assertEquals("mysterious ways", execute(ctx, a));
         }
 
         @Disabled("Spec is vague, so not worth worrying about")
@@ -307,7 +308,7 @@ public class ExpressionTest {
             // Spec is vague on this, so using Satriani as a reference
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout mysterious plus 16");
             Expression a = new Expression(ctx);
-            assertEquals("mysterious16", execute(a));
+            assertEquals("mysterious16", execute(ctx, a));
         }
 
         @Test
@@ -315,7 +316,7 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout 3 - 6", 0);
             Expression a = new Expression(ctx);
             assertNull(a.getValue());
-            double answer = (double) execute(a);
+            double answer = (double) execute(ctx, a);
             assertEquals(-3d, answer);
         }
 
@@ -324,12 +325,12 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout 3 minus 6", 0);
             Expression a = new Expression(ctx);
             assertNull(a.getValue());
-            double answer = (double) execute(a);
+            double answer = (double) execute(ctx, a);
             assertEquals(-3d, answer);
 
             ctx = new ParseHelper().getExpression("shout 8 without 5", 0);
             a = new Expression(ctx);
-            answer = (double) execute(a);
+            answer = (double) execute(ctx, a);
             assertEquals(3d, answer);
         }
 
@@ -338,7 +339,7 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout 3 * 6", 0);
             Expression a = new Expression(ctx);
             assertNull(a.getValue());
-            double answer = (double) execute(a);
+            double answer = (double) execute(ctx, a);
             assertEquals(18d, answer);
         }
 
@@ -347,12 +348,12 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout 3 times 6", 0);
             Expression a = new Expression(ctx);
             assertNull(a.getValue());
-            double answer = (double) execute(a);
+            double answer = (double) execute(ctx, a);
             assertEquals(18d, answer);
 
             ctx = new ParseHelper().getExpression("shout 8 of 5", 0);
             a = new Expression(ctx);
-            answer = (double) execute(a);
+            answer = (double) execute(ctx, a);
             assertEquals(40d, answer);
         }
 
@@ -361,7 +362,7 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout 24/6", 0);
             Expression a = new Expression(ctx);
             assertNull(a.getValue());
-            double answer = (double) execute(a);
+            double answer = (double) execute(ctx, a);
             assertEquals(4, answer);
         }
 
@@ -370,12 +371,12 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout 3 over 6", 0);
             Expression a = new Expression(ctx);
             assertNull(a.getValue());
-            double answer = (double) execute(a);
+            double answer = (double) execute(ctx, a);
             assertEquals(0.5, answer);
 
             ctx = new ParseHelper().getExpression("shout 40 between 5", 0);
             a = new Expression(ctx);
-            answer = (double) execute(a);
+            answer = (double) execute(ctx, a);
             assertEquals(8d, answer);
         }
     }
@@ -388,10 +389,10 @@ public class ExpressionTest {
         public void shouldHandleNegatingBooleans() {
             // Tests the disjunction
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout not ok", 0);
-            assertEquals(false, (boolean) execute(new Expression(ctx)));
+            assertEquals(false, (boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("shout not wrong", 0);
-            assertEquals(true, (boolean) execute(new Expression(ctx)));
+            assertEquals(true, (boolean) execute(ctx, new Expression(ctx)));
         }
 
         @Test
@@ -400,13 +401,13 @@ public class ExpressionTest {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout true and true", 0);
             Expression a = new Expression(ctx);
             assertNull(a.getValue());
-            boolean answer = (boolean) execute(a);
+            boolean answer = (boolean) execute(ctx, a);
             assertEquals(true, answer);
 
             ctx = new ParseHelper().getExpression("shout true and false", 0);
             a = new Expression(ctx);
             assertNull(a.getValue());
-            answer = (boolean) execute(a);
+            answer = (boolean) execute(ctx, a);
             assertEquals(false, answer);
         }
 
@@ -414,32 +415,32 @@ public class ExpressionTest {
         public void shouldHandleOringBooleans() {
             // Tests the disjunction
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout true or true", 0);
-            assertEquals(true, execute(new Expression(ctx)));
+            assertEquals(true, execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("shout false or false", 0);
-            assertEquals(false, execute(new Expression(ctx)));
+            assertEquals(false, execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("shout true or false", 0);
-            assertEquals(true, execute(new Expression(ctx)));
+            assertEquals(true, execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("shout false or true", 0);
-            assertEquals(true, execute(new Expression(ctx)));
+            assertEquals(true, execute(ctx, new Expression(ctx)));
         }
 
         @Test
         public void shouldHandleNoringBooleans() {
             // Tests the disjunction
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout true nor true", 0);
-            assertEquals(false, (boolean) execute(new Expression(ctx)));
+            assertEquals(false, (boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("shout false nor false", 0);
-            assertEquals(true, (boolean) execute(new Expression(ctx)));
+            assertEquals(true, (boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("shout true nor false", 0);
-            assertEquals(false, (boolean) execute(new Expression(ctx)));
+            assertEquals(false, (boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("shout false nor true", 0);
-            assertEquals(false, (boolean) execute(new Expression(ctx)));
+            assertEquals(false, (boolean) execute(ctx, new Expression(ctx)));
         }
 
         // false and 1 over 0 is false and does not produce an error for dividing by zero.
@@ -448,15 +449,15 @@ public class ExpressionTest {
         public void shouldShortCircuitLogicalOperations() {
             // Tests the conjunction
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout false and 1 over 0", 0);
-            assertEquals(false, (boolean) execute(new Expression(ctx)));
+            assertEquals(false, (boolean) execute(ctx, new Expression(ctx)));
 
             // Tests the disjunction
             ctx = new ParseHelper().getExpression("shout true or 1 over 0", 0);
-            assertEquals(true, (boolean) execute(new Expression(ctx)));
+            assertEquals(true, (boolean) execute(ctx, new Expression(ctx)));
 
             // Tests the joint denial
             ctx = new ParseHelper().getExpression("shout true nor 1 over 0", 0);
-            assertEquals(false, (boolean) execute(new Expression(ctx)));
+            assertEquals(false, (boolean) execute(ctx, new Expression(ctx)));
         }
     }
 
@@ -466,161 +467,161 @@ public class ExpressionTest {
         @Test
         public void shouldHandleComparisonOfNumbers() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say 1 is 2", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("shout 1 is 1", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
         }
 
         @Test
         public void shouldHandleComparisonOfBooleans() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say ok is right", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("shout right is wrong", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
         }
 
         @Test
         public void shouldHandleComparisonOfStrings() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say \"life\" is \"life\"", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say \"live\" is \"life\"", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
         }
 
         @Disabled("This also fails to parse in the reference implementation")
         @Test
         public void shouldHandleAintComparisonOfStrings() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say 123 ain’t \"all that\"", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say \"Tommy\" ain’t \"Tommy\"", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
         }
 
         @Test
         public void shouldHandleAintComparisonOfStringsWithNoApostrophe() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say \"Tommy\" aint \"nobody\"", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say \"Tommy\" aint \"Tommy\"", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
         }
 
         @Test
         public void shouldHandleContractionSComparison() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say 123's 123", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 123's 124", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
         }
 
         @Test
         public void shouldHandleGreaterThanComparison() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say 5 is greater than 10", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 2 is stronger than 20", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 20 is stronger than 2", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 20 is higher than 2", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 20 is bigger than 2", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
         }
 
         @Test
         public void shouldReturnFalseForGreaterThanComparisonOfEqualThings() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say 5 is greater than 5", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
         }
 
         @Test
         public void shouldHandleGreaterThanOrEqualComparison() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say 5 is as great as 10", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 2 is as strong as 20", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 20 is as strong as 2", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 20 is as high as 2", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 20 is as big as 2", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             // Equality cases
 
             ctx = new ParseHelper().getExpression("say 5 is as great as 5", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 2 is as strong as 2", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 6 is as high as 6", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 7 is as big as 7", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
         }
 
         @Test
         public void shouldHandleLessThanComparison() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say 15 is less than 10", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 22 is lower than 20", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 2 is weaker than 22", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 20 is smaller than 22", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
         }
 
         @Test
         public void shouldReturnFalseForLessThanComparisonOfEqualThings() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say 5 is less than 5", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
         }
 
         @Test
         public void shouldHandleLessThanOrEqualComparison() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say 15 is as low as 10", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 22 is as little as 20", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 2 is as weak as 22", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 20 is as small as 22", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             // Equality cases
             ctx = new ParseHelper().getExpression("say 15 is as low as 15", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 22 is as little as 22", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 2 is as weak as 2", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say 3 is as small as 3", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
         }
 
         /*
@@ -630,10 +631,10 @@ public class ExpressionTest {
         @Test
         public void shouldHandleLexographicalComparison() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say \"02\" is less than \"10\"", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
             ctx = new ParseHelper().getExpression("say \"02\" is greater than \"10\"", 0);
-            assertFalse((boolean) execute(new Expression(ctx)));
+            assertFalse((boolean) execute(ctx, new Expression(ctx)));
         }
 
         /* "1" is 1 evaluates to true because "1" gets converted to the number 1 */
@@ -641,7 +642,7 @@ public class ExpressionTest {
         @Test
         public void shouldHandleCastingInComparison() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say \"1\" is 1", 0);
-            assertTrue((boolean) execute(new Expression(ctx)));
+            assertTrue((boolean) execute(ctx, new Expression(ctx)));
         }
 
         /**
@@ -651,7 +652,7 @@ public class ExpressionTest {
         @Test
         public void shouldNotAllowComparisonBetweenBooleanAndNumbers() {
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say true is less than 10", 0);
-            assertThrows(Throwable.class, () -> execute(new Expression(ctx)));
+            assertThrows(Throwable.class, () -> execute(ctx, new Expression(ctx)));
         }
     }
 
@@ -661,7 +662,7 @@ public class ExpressionTest {
     @Test
     public void shouldFindAnythingExceptMysteriousIsNotMysterious() {
         Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say \"2\" ain't Mysterious", 0);
-        assertTrue((boolean) execute(new Expression(ctx)));
+        assertTrue((boolean) execute(ctx, new Expression(ctx)));
     }
 
     /*
@@ -670,37 +671,37 @@ public class ExpressionTest {
     @Test
     public void shouldHaveMysteriousEqualToItself() {
         Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say mysterious ain't Mysterious", 0);
-        assertFalse((boolean) execute(new Expression(ctx)));
+        assertFalse((boolean) execute(ctx, new Expression(ctx)));
     }
 
     @Test
     public void shouldTreatNothingAsEqualToFalse() {
         Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say wrong ain't nothing", 0);
-        assertFalse((boolean) execute(new Expression(ctx)));
+        assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
         ctx = new ParseHelper().getExpression("say nothing ain't wrong", 0);
-        assertFalse((boolean) execute(new Expression(ctx)));
+        assertFalse((boolean) execute(ctx, new Expression(ctx)));
     }
 
     @Test
     public void shouldTreatNothingAsNotEqualToTrue() {
         Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say right ain't nothing", 0);
-        assertTrue((boolean) execute(new Expression(ctx)));
+        assertTrue((boolean) execute(ctx, new Expression(ctx)));
 
         ctx = new ParseHelper().getExpression("say nothing ain't right", 0);
-        assertTrue((boolean) execute(new Expression(ctx)));
+        assertTrue((boolean) execute(ctx, new Expression(ctx)));
     }
 
     @Test
     public void shouldTreatNothingAsEqualToZero() {
         Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say 0 ain't nothing", 0);
-        assertFalse((boolean) execute(new Expression(ctx)));
+        assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
         new ParseHelper().getExpression("say nothing ain't 0", 0);
-        assertFalse((boolean) execute(new Expression(ctx)));
+        assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
         ctx = new ParseHelper().getExpression("say 0 is nothing", 0);
-        assertTrue((boolean) execute(new Expression(ctx)));
+        assertTrue((boolean) execute(ctx, new Expression(ctx)));
     }
 
     @Test
@@ -708,33 +709,33 @@ public class ExpressionTest {
         Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say nothing", 0);
 
         Expression expr = new Expression(ctx);
-        assertNotNull(execute(expr));
-        assertEquals(NOTHING, execute(expr));
+        assertNotNull(execute(ctx, expr));
+        assertEquals(NOTHING, execute(ctx, expr));
     }
 
     @Test
     public void shouldPassBackNullObjectForMysterious() {
         Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say mysterious", 0);
-        assertNull(execute(new Expression(ctx)));
+        assertNull(execute(ctx, new Expression(ctx)));
     }
 
     // The spec is a bit vague on this, so this is based on observation in Satriani
     @Test
     public void shouldTreatNothingAsEqualToEmptyStringForComparisons() {
         Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say \"\" ain't nothing", 0);
-        assertFalse((boolean) execute(new Expression(ctx)));
+        assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
         ctx = new ParseHelper().getExpression("say \"\" is nothing", 0);
-        assertTrue((boolean) execute(new Expression(ctx)));
+        assertTrue((boolean) execute(ctx, new Expression(ctx)));
     }
 
     @Test
     public void shouldHaveNothingEqualToItself() {
         Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("say nothing ain't gone", 0);
-        assertFalse((boolean) execute(new Expression(ctx)));
+        assertFalse((boolean) execute(ctx, new Expression(ctx)));
 
         ctx = new ParseHelper().getExpression("say nothing is gone", 0);
-        assertTrue((boolean) execute(new Expression(ctx)));
+        assertTrue((boolean) execute(ctx, new Expression(ctx)));
     }
 
     @Test
@@ -745,7 +746,8 @@ public class ExpressionTest {
             MethodCreator main = creator.getMethodCreator("main", void.class, String[].class);
 
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout \"hello\"");
-            ResultHandle handle = new Expression(ctx).getResultHandle(main, creator);
+            Block block = new Block(ctx, main, creator, new VariableScope(), null);
+            ResultHandle handle = new Expression(ctx).getResultHandle(block);
 
             // We can't interrogate the type directly, so read it from the string
             assertTrue(handle.toString()
@@ -761,7 +763,8 @@ public class ExpressionTest {
             MethodCreator main = creator.getMethodCreator("main", void.class, String[].class);
 
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout 5");
-            ResultHandle handle = new Expression(ctx).getResultHandle(main, creator);
+            Block block = new Block(ctx, main, creator, new VariableScope(), null);
+            ResultHandle handle = new Expression(ctx).getResultHandle(block);
 
             // We can't interrogate the type directly, so read it from the string
             assertTrue(handle.toString()
@@ -778,7 +781,9 @@ public class ExpressionTest {
             MethodCreator main = creator.getMethodCreator("main", void.class, String[].class);
 
             Rockstar.ExpressionContext ctx = new ParseHelper().getExpression("shout ok");
-            ResultHandle handle = new Expression(ctx).getResultHandle(main, creator);
+            Block block = new Block(ctx, main, creator, new VariableScope(), null);
+
+            ResultHandle handle = new Expression(ctx).getResultHandle(block);
 
             // We can't interrogate the type directly, so read it from the string
             assertTrue(handle.toString()
@@ -811,7 +816,8 @@ public class ExpressionTest {
 
             MethodCreator method = creator.getMethodCreator("method", Object.class)
                     .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
-            ResultHandle handle = new Expression(ctx).getResultHandle(method, creator);
+            Block block = new Block(ctx, method, creator, new VariableScope(), null);
+            ResultHandle handle = new Expression(ctx).getResultHandle(block);
 
             // We can't really know the return type of a function, so go with Object
             assertTrue(handle.toString()
@@ -867,11 +873,11 @@ public class ExpressionTest {
         }
     }
 
-    private Object execute(Expression a) {
-        return execute(a, Expression.Context.NORMAL);
+    private Object execute(ParserRuleContext ctx, Expression a) {
+        return execute(ctx, a, Expression.Context.NORMAL);
     }
 
-    private Object execute(Expression a, Expression.Context context) {
+    private Object execute(ParserRuleContext ctx, Expression a, Expression.Context context) {
         TestClassLoader cl = new TestClassLoader(this.getClass().getClassLoader());
 
         // The auto-close on this triggers the write
@@ -882,7 +888,8 @@ public class ExpressionTest {
 
             MethodCreator method = creator.getMethodCreator("method", Object.class)
                     .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
-            ResultHandle rh = a.getResultHandle(method, creator, context);
+            Block block = new Block(ctx, method, creator, new VariableScope(), null);
+            ResultHandle rh = a.getResultHandle(block, context);
             method.returnValue(rh);
         }
 

--- a/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/InputTest.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/InputTest.java
@@ -73,9 +73,11 @@ public class InputTest {
 
             MethodCreator method = creator.getMethodCreator(methodName, Object.class, String[].class)
                     .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+            // Cheat and pass null for the context and hope it doesn't blow up
+            Block block = new Block(null, method, creator, new VariableScope(), null);
 
-            Variable v = a.toCode(creator, method, method);
-            ResultHandle rh = v.getResultHandle(method);
+            Variable v = a.toCode(block, method);
+            ResultHandle rh = v.getResultHandle(block);
             method.returnValue(rh);
         }
 

--- a/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/LiteralTest.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/LiteralTest.java
@@ -5,6 +5,7 @@ import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.gizmo.TestClassLoader;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
@@ -63,24 +64,24 @@ public class LiteralTest {
         Rockstar.LiteralContext ctx = new ParseHelper().getLiteral("thing is \"Yes hello\"");
         Literal a = new Literal(ctx);
         assertEquals("Yes hello", a.getValue());
-        assertEquals("Yes hello", execute(a));
+        assertEquals("Yes hello", execute(ctx, a));
     }
 
     @Test
     public void shouldReturnCorrectBytecodeForStringLiterals() {
         Rockstar.LiteralContext ctx = new ParseHelper().getLiteral("thing is \"Yes hello\"");
         Literal a = new Literal(ctx);
-        assertEquals("Yes hello", execute(a));
+        assertEquals("Yes hello", execute(ctx, a));
     }
 
     @Test
     public void shouldReturnCorrectBytecodeForNumberLiterals() {
         Rockstar.LiteralContext ctx = new ParseHelper().getLiteral("thing is 61");
         Literal a = new Literal(ctx);
-        assertEquals(61d, execute(a));
+        assertEquals(61d, execute(ctx, a));
     }
 
-    private Object execute(Literal a) {
+    private Object execute(ParserRuleContext ctx, Literal a) {
         TestClassLoader cl = new TestClassLoader(this.getClass().getClassLoader().getParent());
 
         // The auto-close on this triggers the write
@@ -91,7 +92,9 @@ public class LiteralTest {
 
             MethodCreator method = creator.getMethodCreator("method", Object.class)
                     .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
-            ResultHandle rh = a.getResultHandle(method);
+            Block block = new Block(ctx, method, creator, new VariableScope(), null);
+
+            ResultHandle rh = a.getResultHandle(block);
             method.returnValue(rh);
         }
 

--- a/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/ParameterTest.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/ParameterTest.java
@@ -16,20 +16,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class VariableTest {
-
+public class ParameterTest {
     // The variable test doesn't need to care about the class we pass in
     private static final Class<?> defaultVariableClass = Object.class;
 
     @BeforeEach
     public void clearState() {
-        Variable.clearState();
+        Parameter.clearState();
     }
 
     @Test
     public void shouldParseIntegerLiteralsAsVariables() {
         Rockstar.VariableContext ctx = new ParseHelper().getVariable("my thing is 5\nshout my thing");
-        Variable a = new Variable(ctx, double.class);
+        Parameter a = new Parameter(ctx, double.class);
         // The 'value' is the variable name
         assertEquals("my__thing", a.getVariableName());
 
@@ -43,13 +42,13 @@ public class VariableTest {
     @Test
     public void shouldHandleSimpleVariableNames() {
         String program = """
-                Variable is "Hello San Francisco"
-                Shout Variable
+                Parameter is "Hello San Francisco"
+                Shout Parameter
                                             """;
         Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
-        Variable v = new Variable(ctx, String.class);
+        Parameter v = new Parameter(ctx, String.class);
 
-        assertEquals("variable", v.getVariableName());
+        assertEquals("parameter", v.getVariableName());
     }
 
     /*
@@ -66,7 +65,7 @@ public class VariableTest {
                 Shout my thing
                                             """;
         Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
-        Variable v = new Variable(ctx, boolean.class);
+        Parameter v = new Parameter(ctx, boolean.class);
         assertEquals("my__thing", v.getVariableName());
     }
 
@@ -77,7 +76,7 @@ public class VariableTest {
                 Shout our thing
                                             """;
         Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
-        Variable v = new Variable(ctx, boolean.class);
+        Parameter v = new Parameter(ctx, boolean.class);
         assertEquals("our__thing", v.getVariableName());
     }
 
@@ -88,7 +87,7 @@ public class VariableTest {
                 Shout my   thing
                                             """;
         Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
-        Variable v = new Variable(ctx, boolean.class);
+        Parameter v = new Parameter(ctx, boolean.class);
         assertEquals("my__thing", v.getVariableName());
     }
 
@@ -100,7 +99,7 @@ public class VariableTest {
                 Shout your lies
                                             """;
         Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
-        Variable v = new Variable(ctx, boolean.class);
+        Parameter v = new Parameter(ctx, boolean.class);
         assertEquals("my__thing", v.getVariableName());
     }
 
@@ -123,7 +122,7 @@ public class VariableTest {
                 Shout Doctor FeelGOOD
                                             """;
         Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
-        Variable v = new Variable(ctx, double.class);
+        Parameter v = new Parameter(ctx, double.class);
         assertEquals("doctor__feelgood", v.getVariableName());
     }
 
@@ -133,7 +132,7 @@ public class VariableTest {
                 tIMe is an illusion
                                             """;
         Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
-        Variable v = new Variable(ctx, defaultVariableClass);
+        Parameter v = new Parameter(ctx, defaultVariableClass);
         assertEquals("time", v.getVariableName());
     }
 
@@ -143,7 +142,7 @@ public class VariableTest {
                 TIME is an illusion
                                             """;
         Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
-        Variable v = new Variable(ctx, defaultVariableClass);
+        Parameter v = new Parameter(ctx, defaultVariableClass);
         assertEquals("time", v.getVariableName());
     }
 
@@ -161,7 +160,7 @@ public class VariableTest {
                 Shout my thing
                                             """;
         Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
-        Variable v = new Variable(ctx, defaultVariableClass);
+        Parameter v = new Parameter(ctx, defaultVariableClass);
         assertEquals("my__thing", v.getVariableName());
     }
 
@@ -173,7 +172,7 @@ public class VariableTest {
     public void shouldHandleVariableAssignmentToPoeticNumberLiterals() {
         String program = "Rockstar is a big bad monster";
         Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
-        Variable v = new Variable(ctx, defaultVariableClass);
+        Parameter v = new Parameter(ctx, defaultVariableClass);
 
         assertEquals("rockstar", v.getVariableName());
     }
@@ -188,7 +187,7 @@ public class VariableTest {
                 Shout X
                 """;
         Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
-        Variable v = new Variable(ctx, defaultVariableClass);
+        Parameter v = new Parameter(ctx, defaultVariableClass);
         assertEquals("x", v.getVariableName());
     }
 
@@ -202,28 +201,8 @@ public class VariableTest {
                 Shout my balance
                 """;
         Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
-        Variable v = new Variable(ctx, defaultVariableClass);
+        Parameter v = new Parameter(ctx, defaultVariableClass);
         assertEquals("my__balance", v.getVariableName());
-    }
-
-    @Test
-    public void shouldHandleStringLiteralPronounReferences() {
-
-        // This is a bit of a convoluted test, because the thin skeleton we're using for creating the variable does invoke other parts of
-        // the parse logic, such as assignments
-
-        String program = "The message is \"pass\"";
-        Rockstar.VariableContext ctx = new ParseHelper().getVariable(program);
-        Variable v = new Variable(ctx, defaultVariableClass);
-        v.track();
-
-        program = "shout it";
-
-        ctx = new ParseHelper().getVariable(program);
-        v = new Variable(ctx, defaultVariableClass);
-
-        // Now go again and make sure we can interpret the pronoun
-        assertEquals("the__message", v.getVariableName());
     }
 
     @Disabled("type chaos")
@@ -238,7 +217,7 @@ public class VariableTest {
         Block block = new Block(ctx, method, creator, new VariableScope(), null);
 
         // The class here needs to match the class of what we load into the result handle
-        Variable variable = new Variable(ctx, String.class);
+        Parameter variable = new Parameter(ctx, String.class);
         String className = "soundcheck";
         ResultHandle writtenValue = method.load(className);
         variable.write(block, writtenValue);
@@ -264,7 +243,7 @@ public class VariableTest {
         Block block = new Block(ctx, method, creator, new VariableScope(), null);
 
         // The class here needs to match the class of what we load into the result handle
-        Variable variable = new Variable(ctx, String.class);
+        Parameter variable = new Parameter(ctx, String.class);
         String className = "soundcheck";
         ResultHandle writtenValue = method.load(className);
         variable.write(block, writtenValue);
@@ -272,7 +251,7 @@ public class VariableTest {
         assertTrue(readValue.toString().contains("type='Ljava/lang/String;'"), readValue.toString());
 
         Rockstar.VariableContext ctx2 = new ParseHelper().getVariable("johnny is 4");
-        Variable variable2 = new Variable(ctx2, double.class);
+        Parameter variable2 = new Parameter(ctx2, double.class);
         // Sense check
         assertEquals(double.class, variable2.getVariableClass());
         ResultHandle writtenValue2 = method.load(2d);
@@ -294,7 +273,7 @@ public class VariableTest {
         Rockstar.VariableContext ctx = new ParseHelper().getVariable("fred is 5");
         Block block = new Block(ctx, method, creator, new VariableScope(), null);
 
-        Variable variable = new Variable(ctx, defaultVariableClass);
+        Parameter variable = new Parameter(ctx, defaultVariableClass);
 
         variable.write(block, method.load(0));
         fields = creator.getExistingFields();
@@ -303,7 +282,7 @@ public class VariableTest {
 
         // Now a second variable instance with the same name should return the same field
         ctx = new ParseHelper().getVariable("fred is 8");
-        variable = new Variable(ctx, defaultVariableClass);
+        variable = new Parameter(ctx, defaultVariableClass);
 
         variable.write(block, method.load(1));
         fields = creator.getExistingFields();
@@ -323,7 +302,7 @@ public class VariableTest {
         Rockstar.VariableContext ctx = new ParseHelper().getVariable("My thing is 6");
         Block block = new Block(ctx, method, creator, new VariableScope(), null);
 
-        Variable variable = new Variable(ctx, defaultVariableClass);
+        Parameter variable = new Parameter(ctx, defaultVariableClass);
 
         variable.write(block, method.load(2));
         assertEquals("my__thing", creator.getExistingFields().iterator().next().getName());


### PR DESCRIPTION
This resolves #99, and partially resolves #112.

There's still some problems in the generated bytecode, caused by use of static variables where we should use method-scoped variables (assignable result handles, maybe?), but the external behaviour is now correct. 