### PR TITLE
Allow return statements to (effectively) terminate statement lists

### DIFF
--- a/quarkus-bon-jova-rockstar/compiler/src/main/antlr4/rock/Rockstar.g4
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/antlr4/rock/Rockstar.g4
@@ -2,12 +2,14 @@ parser grammar Rockstar;
 
 options { tokenVocab=RockstarLexer; }
 
-program: (NL|ws)* (statementList | functionDeclaration)* ws*;
+program: (NL|ws)* terminatedStatementList* ws*;
 
+terminatedStatementList: (statementList | functionDeclaration)+ returnStmt?;
 statementList: statement+;
 
-statement: ws* (ifStmt | inputStmt | outputStmt | assignmentStmt | roundingStmt | incrementStmt | decrementStmt | loopStmt | arrayStmt | stringStmt | castStmt | joinStmt | continueStmt | breakStmt) (NL+?|EOF);
+returnStmt: ws* KW_GIVE (ws KW_BACK)? ws expression (ws KW_BACK)? (NL+?|EOF);
 
+statement: ws* (ifStmt | inputStmt | outputStmt | assignmentStmt | roundingStmt | incrementStmt | decrementStmt | loopStmt | arrayStmt | stringStmt | castStmt | joinStmt | continueStmt | breakStmt ) (NL+?|EOF)?;
 
 expression: functionCall
           | lhe=expression ws op=(KW_MULTIPLY|KW_DIVIDE) ws rhe=expression extraExpressions?
@@ -44,7 +46,7 @@ functionCall: functionName=variable WS KW_TAKING WS argList;
 // the second set of entries here isn't just an expression, to try and force the shortest match, rather than the longest match
 argList: (expression) ((WS KW_AND|COMMA|WS AMPERSAND|WS APOSTROPHED_N) WS (literal|variable|constant|expression))*;
 
-functionDeclaration: functionName=variable WS KW_TAKES WS paramList NL statementList? ws* returnStmt (NL+?|EOF);
+functionDeclaration: functionName=variable WS KW_TAKES WS paramList NL statementList?;
 
 paramList: variable ((COMMA? WS* KW_AND WS | WS COMMA WS | WS AMPERSAND WS | WS APOSTROPHED_N WS) variable)*;
 
@@ -88,8 +90,6 @@ castStmt: KW_CAST ws expression (ws KW_INTO ws variable)? ws KW_WITH ws expressi
 ;
 
 joinStmt: KW_JOIN ws variable (ws KW_INTO ws variable)? (ws KW_WITH ws expression)?;
-
-returnStmt: KW_GIVE (ws KW_BACK)? ws expression (ws KW_BACK)?;
 
 continueStmt: KW_CONTINUE;
 

--- a/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/BytecodeGeneratingListener.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/main/java/io/quarkiverse/bonjova/compiler/BytecodeGeneratingListener.java
@@ -391,7 +391,7 @@ public class BytecodeGeneratingListener extends RockstarBaseListener {
 
     @Override
     public void exitFunctionDeclaration(Rockstar.FunctionDeclarationContext ctx) {
-        exitBlock();
+        // Do nothing, as the return statement handles exiting the block (the return is not part of the function declaration)
     }
 
     @Override
@@ -411,6 +411,12 @@ public class BytecodeGeneratingListener extends RockstarBaseListener {
         ResultHandle rh = e.getResultHandle(currentBlock);
 
         currentBlock.method().returnValue(rh);
+
+        // We could have repeated returns, so check we have a block before exiting
+        if (isSafeToExitBlock()) {
+            exitBlock();
+        }
+
     }
 
     @Override
@@ -428,9 +434,13 @@ public class BytecodeGeneratingListener extends RockstarBaseListener {
 
     @Override
     public void exitStatementList(Rockstar.StatementListContext ctx) {
-        if (blocks.size() > 1) {
+        if (isSafeToExitBlock()) {
             exitBlock();
         }
+    }
+
+    private boolean isSafeToExitBlock() {
+        return blocks.size() > 1;
     }
 
     private void exitBlock() {

--- a/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/integration/IntegrationTests.java
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/java/io/quarkiverse/bonjova/compiler/integration/IntegrationTests.java
@@ -16,8 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class IntegrationTests {
     @ParameterizedTest(name = "{1}")
     @MethodSource("provideTestData")
-    void runningRockstarProgramShouldYieldExpectedOutput(String inputFile, String rockstarFile,
-            String expectedOutputFile) throws IOException, URISyntaxException {
+    void runningRockstarProgramShouldYieldExpectedOutput(String inputFile, String rockstarFile, String expectedOutputFile)
+            throws IOException, URISyntaxException {
         String output;
 
         if (inputFile != null) {

--- a/quarkus-bon-jova-rockstar/compiler/src/test/resources/mandelbrot.rock
+++ b/quarkus-bon-jova-rockstar/compiler/src/test/resources/mandelbrot.rock
@@ -27,7 +27,6 @@ Cast your need into your anger
 If the expectations are weaker than the goal
 Let the answer be your anger,
 Else let the answer be your thoughts
-
 Give the answer
 
 Peace takes time


### PR DESCRIPTION
Resolves #154. 

The behaviour is still not identical to Satriani; now, a blank line before the 'give' will cause bad behaviour in Satriani, and work in Bon Jova. Similarly, Satriani *requires* a blank line before the 'give' in a loop, in Bon Jova does not. 

However, the current behaviour seems consistent with the spec and unlikely to cause problems (the old requirement for a blank line meant the mandelbrot code couldn't be copy-pasted from the Rockstar samples, for example). 