### PR TITLE
Update to Quarkus 3.9.1 to get new code block in dev ui

### DIFF
--- a/bon-jova-app/pom.xml
+++ b/bon-jova-app/pom.xml
@@ -18,7 +18,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.6.4</quarkus.platform.version>
+        <quarkus.platform.version>3.9.4</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
     </properties>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>io.quarkiverse.bonjova</groupId>
             <artifactId>quarkus-bon-jova</artifactId>
-            <version>0.7.0-SNAPSHOT</version>
+            <version>0.6.0</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/bon-jova-app/pom.xml
+++ b/bon-jova-app/pom.xml
@@ -18,7 +18,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.9.4</quarkus.platform.version>
+        <quarkus.platform.version>3.8.4</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
     </properties>

--- a/quarkus-bon-jova-rockstar/deployment/src/main/resources/dev-ui/qwc-bon-jova-rockstar-endpoints.js
+++ b/quarkus-bon-jova-rockstar/deployment/src/main/resources/dev-ui/qwc-bon-jova-rockstar-endpoints.js
@@ -5,14 +5,16 @@ import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
 import '@vaadin/details';
 import 'echarts-gauge-grade';
-import 'qui-code-block';
+import '@quarkus-webcomponents/codeblock';
 import 'qui-ide-link';
 import 'qui-badge';
+import {observeState} from "./lit-state";
+import {themeState} from "./theme-state";
 
 /**
  * This component shows the Rockstar endpoints.
  */
-export class QwcBonJovaRockstarEndpoints extends LitElement {
+export class QwcBonJovaRockstarEndpoints extends observeState(LitElement) {
     static styles = css`
         .bonjova {
             height: 100%;
@@ -23,7 +25,7 @@ export class QwcBonJovaRockstarEndpoints extends LitElement {
             color: var(--lumo-primary-text-color);
             text-decoration: none;
         }
-        
+
         .cardGrid {
             display: flex;
             flex-wrap: wrap;
@@ -32,7 +34,7 @@ export class QwcBonJovaRockstarEndpoints extends LitElement {
             padding-left: 5px;
             padding-right: 10px;
         }
-        
+
         .detailCard {
             min-width: 400px;
         }
@@ -44,7 +46,7 @@ export class QwcBonJovaRockstarEndpoints extends LitElement {
             padding-right: 10px;
             min-height: 300px;
         }
-        
+
         .rockScoreChart {
             height: 300px;
         }
@@ -130,7 +132,7 @@ export class QwcBonJovaRockstarEndpoints extends LitElement {
                     <div slot="content">
                         <div class="codeBlock">
                             <qui-code-block mode="java"
-                                            content="${rockFile.contents}">
+                                            content="${rockFile.contents}" theme="${themeState.theme.name}">
                             </qui-code-block>
                         </div>
                     </div>

--- a/quarkus-bon-jova-rockstar/deployment/src/main/resources/dev-ui/qwc-bon-jova-rockstar-endpoints.js
+++ b/quarkus-bon-jova-rockstar/deployment/src/main/resources/dev-ui/qwc-bon-jova-rockstar-endpoints.js
@@ -8,8 +8,8 @@ import 'echarts-gauge-grade';
 import '@quarkus-webcomponents/codeblock';
 import 'qui-ide-link';
 import 'qui-badge';
-import {observeState} from "./lit-state";
-import {themeState} from "./theme-state";
+import {observeState} from "lit-element-state";
+import {themeState} from "theme-state";
 
 /**
  * This component shows the Rockstar endpoints.
@@ -28,8 +28,7 @@ export class QwcBonJovaRockstarEndpoints extends observeState(LitElement) {
 
         .cardGrid {
             display: flex;
-            flex-wrap: wrap;
-            align-items: stretch;
+            justify-content: space-between;
             gap: 20px;
             padding-left: 5px;
             padding-right: 10px;
@@ -128,7 +127,8 @@ export class QwcBonJovaRockstarEndpoints extends observeState(LitElement) {
         let level = this._getLevel(rockFile.rockScore);
         return html`
             <div class="cardGrid">
-                <qui-card class="detailCard" title="Program Contents">
+                <qui-card class="detailCard" title="Program Contents"
+                          style="width:100%">
                     <div slot="content">
                         <div class="codeBlock">
                             <qui-code-block mode="java"

--- a/quarkus-bon-jova-rockstar/deployment/src/test/java/io/quarkiverse/bonjova/quarkus/extension/deployment/RockstarCompilationProviderTest.java
+++ b/quarkus-bon-jova-rockstar/deployment/src/test/java/io/quarkiverse/bonjova/quarkus/extension/deployment/RockstarCompilationProviderTest.java
@@ -60,7 +60,7 @@ class RockstarCompilationProviderTest {
                 null,
                 null,
                 null,
-                null);
+                null, null, null, null);
     }
 
     @AfterAll

--- a/quarkus-bon-jova-rockstar/pom.xml
+++ b/quarkus-bon-jova-rockstar/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -42,7 +43,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.6.4</quarkus.version>
+        <quarkus.version>3.9.1</quarkus.version>
         <surefire-plugin.version>3.0.0</surefire-plugin.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
Following instructions for code changes in https://github.com/quarkusio/quarkus/pull/38848.

Marking as draft, since at the moment this update makes the endpoint list disappear.